### PR TITLE
Credit Forrest as the author, list ASF APD/Tools as maintainers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,12 @@ name = "burst2safe"
 requires-python = ">=3.9"
 dynamic = ["version"]
 authors = [
-    {name="tools-bot", email="UAF-asf-apd@alaska.edu"},
+     {name="Forrest Williams", email="ffwilliams2@alaska.edu"},
 ]
+maintainers = [
+    {name="ASF APD/Tools Team", email="uaf-asf-apd@alaska.edu"},
+]
+
 description = "A package for converting ASF-derived Sentinel-1 burst SLC products to the ESA SAFE format"
 readme = "README.md"
 classifiers=[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ name = "burst2safe"
 requires-python = ">=3.9"
 dynamic = ["version"]
 authors = [
-     {name="Forrest Williams", email="ffwilliams2@alaska.edu"},
+    {name="Forrest Williams", email="ffwilliams2@alaska.edu"},
 ]
 maintainers = [
     {name="ASF APD/Tools Team", email="uaf-asf-apd@alaska.edu"},


### PR DESCRIPTION
@forrestfwilliams did author this packageand the Tools team is taking over maintenance/stewardship, so I think leaving Forrest as the author and using the maintainer's section for the team would be more appropriate. 

Admittedly, this is a minor quibble. 

See: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#about-your-project