### PR TITLE
Start upgrading to mypy action v0.15.0

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -13,4 +13,4 @@ jobs:
 
   call-mypy-workflow:
     # Docs: https://github.com/ASFHyP3/actions
-    uses: ASFHyP3/actions/.github/workflows/reusable-mypy.yml@v0.14.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-mypy.yml@v0.15.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,3 +99,7 @@ warn_unused_ignores = true
 warn_unreachable = true
 strict_equality = true
 check_untyped_defs = true
+install_types = true
+non_interactive = true
+pretty = true
+disable_error_code = ["import-untyped"]

--- a/src/burst2safe/utils.py
+++ b/src/burst2safe/utils.py
@@ -183,7 +183,7 @@ def calculate_crc16(file_path: Path) -> str:
 
 def get_subxml_from_metadata(
     metadata_path: Path, xml_type: str, subswath: Optional[str] = None, polarization: Optional[str] = None
-) -> ET.Element:
+) -> Optional[ET._Element]:
     """Extract child xml info from ASF combined metadata file.
 
     Args:


### PR DESCRIPTION
There are >250 errors now that we're not using `--ignore-missing-imports` (see <https://github.com/ASFHyP3/actions/issues/225>).