### PR TITLE
Change in check for RFI detection from noise report

### DIFF
--- a/src/burst2safe/rfi.py
+++ b/src/burst2safe/rfi.py
@@ -55,8 +55,7 @@ class Rfi(Annotation):
         assert self.rfi_burst_report_list is not None
         rfi.append(self.ads_header)
         rfi.append(self.rfi_mitigation_applied)
-        if not self.rfi_mitigation_applied.text == 'None':
-            assert self.rfi_detection_from_noise_report_list is not None
+        if self.rfi_detection_from_noise_report_list is not None:
             rfi.append(self.rfi_detection_from_noise_report_list)
         rfi.append(self.rfi_burst_report_list)
         rfi_tree = ET.ElementTree(rfi)


### PR DESCRIPTION
This is a small PR to correct the assumption of not having `rfiDetectionFromNoiseReportList` when `rfiMitigationApplied` is `None`. This does not happen with `S1_259697_EW4_20240705T211146_HV_FAAC-BURST`