### PR TITLE
Bug/burst topology check

### DIFF
--- a/src/burst2safe/safe.py
+++ b/src/burst2safe/safe.py
@@ -172,7 +172,9 @@ class Safe:
 
         Returns: np.array representing a truth table for included bursts
         """
-        burst_ids = sorted(list(set([info.burst_id for info in burst_infos])))
+        burst_ids = sorted([b for b in {info.burst_id for info in burst_infos} if b is not None])
+        if not burst_ids:
+            raise ValueError("No burst IDs found in any BurstInfo")
 
         # fail fast
         expected_burst_ids = list(range(min(burst_ids), max(burst_ids) + 1))

--- a/src/burst2safe/safe.py
+++ b/src/burst2safe/safe.py
@@ -113,11 +113,7 @@ class Safe:
         hole_count = 0
 
         # 8-connectivity
-        directions = [
-            (-1, -1), (-1, 0), (-1, 1),
-            ( 0, -1),          ( 0, 1),
-            ( 1, -1), ( 1, 0), ( 1, 1)
-            ]
+        directions = [(-1, -1), (-1, 0), (-1, 1), (0, -1), (0, 1), (1, -1), (1, 0), (1, 1)]
 
         for r in range(nrows):
             for c in range(ncols):
@@ -139,7 +135,7 @@ class Safe:
                                     visited[ny, nx] = True
                                     queue.append((ny, nx))
                 else:  # False → possible hole
-                    touches_border = (r == 0 or r == nrows-1 or c == 0 or c == ncols-1)
+                    touches_border = r == 0 or r == nrows - 1 or c == 0 or c == ncols - 1
                     region = [(r, c)]
                     while queue:
                         y, x = queue.popleft()
@@ -150,14 +146,14 @@ class Safe:
                                     visited[ny, nx] = True
                                     queue.append((ny, nx))
                                     region.append((ny, nx))
-                                    if ny == 0 or ny == nrows-1 or nx == 0 or nx == ncols-1:
+                                    if ny == 0 or ny == nrows - 1 or nx == 0 or nx == ncols - 1:
                                         touches_border = True
                     if not touches_border:
                         hole_count += 1
         if component_count > 1 or hole_count > 0:
             msg = (
-                "Multiburst collections must be comprised of a single connected component and have no holes.\n"
-                f"Connected Components: {component_count}, Holes: {hole_count}"
+                'Multiburst collections must be comprised of a single connected component and have no holes.\n'
+                f'Connected Components: {component_count}, Holes: {hole_count}'
             )
             raise ValueError(msg)
 
@@ -174,22 +170,22 @@ class Safe:
         """
         burst_ids = sorted([b for b in {info.burst_id for info in burst_infos} if b is not None])
         if not burst_ids:
-            raise ValueError("No burst IDs found in any BurstInfo")
+            raise ValueError('No burst IDs found in any BurstInfo')
 
         # fail fast
         expected_burst_ids = list(range(min(burst_ids), max(burst_ids) + 1))
         if burst_ids != expected_burst_ids:
-            raise ValueError(f"There can be no gaps in burst IDs accross a collection of bursts. Found: {burst_ids}")
+            raise ValueError(f'There can be no gaps in burst IDs accross a collection of bursts. Found: {burst_ids}')
 
         burst_swath_mask = []
         for burst in burst_ids:
             burst_info = [info for info in burst_infos if burst == info.burst_id]
             burst_swaths = list(set([i.swath for i in burst_info]))
             swath_mask = [
-                any("1" in i for i in burst_swaths),
-                any("2" in i for i in burst_swaths),
-                any("3" in i for i in burst_swaths)
-                ]
+                any('1' in i for i in burst_swaths),
+                any('2' in i for i in burst_swaths),
+                any('3' in i for i in burst_swaths),
+            ]
             burst_swath_mask.append(swath_mask)
         return np.array(burst_swath_mask)
 
@@ -238,16 +234,6 @@ class Safe:
 
         if len(swaths) == 1:
             return
-
-        swath_combos = [[swaths[i], swaths[i + 1]] for i in range(len(swaths) - 1)]
-        working_pol = polarizations[0]
-        for swath1, swath2 in swath_combos:
-            min_diff = burst_range[swath1][working_pol][0] - burst_range[swath2][working_pol][0]
-            if np.abs(min_diff) > 1:
-                raise ValueError(f'Products from swaths {swath1} and {swath2} do not overlap')
-            max_diff = burst_range[swath1][working_pol][1] - burst_range[swath2][working_pol][1]
-            if np.abs(max_diff) > 1:
-                raise ValueError(f'Products from swaths {swath1} and {swath2} do not overlap')
 
     def get_name(self, unique_id: str = '0000') -> str:
         """Create a name for the SAFE file.

--- a/src/burst2safe/safe.py
+++ b/src/burst2safe/safe.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import List, Optional, Tuple, Union, cast
 
 import numpy as np
+from numpy.typing import NDArray
 from shapely.geometry import MultiPolygon, Polygon
 
 from burst2safe.base import create_content_unit, create_data_object, create_metadata_object
@@ -82,7 +83,7 @@ class Safe:
         return data_dir / f'support_{support_version}'
 
     @staticmethod
-    def count_components_and_holes(burst_swath_mask: np.array) -> None:
+    def count_components_and_holes(burst_swath_mask: NDArray[np.bool_]) -> None:
         """
         Performs a BFS search to count connected components and holes
 
@@ -161,7 +162,7 @@ class Safe:
             raise ValueError(msg)
 
     @staticmethod
-    def make_burst_swath_mask(burst_infos: Iterable[BurstInfo]) -> np.array:
+    def make_burst_swath_mask(burst_infos: Iterable[BurstInfo]) -> NDArray[np.bool_]:
         """
         Creates a mask of bursts/swaths included in a burst collection.
         Useful when using a BFS to identify invalid topologies in collections of bursts.
@@ -176,7 +177,7 @@ class Safe:
         # fail fast
         expected_burst_ids = list(range(min(burst_ids), max(burst_ids) + 1))
         if burst_ids != expected_burst_ids:
-            raise ValueError(f"There can be no gaps in burst IDs accross a collection of bursts. Burst IDs: {burst_ids}")
+            raise ValueError(f"There can be no gaps in burst IDs accross a collection of bursts. Found: {burst_ids}")
 
         burst_swath_mask = []
         for burst in burst_ids:

--- a/src/burst2safe/swath.py
+++ b/src/burst2safe/swath.py
@@ -92,8 +92,6 @@ class Swath:
 
         burst_ids = [cast(int, x.burst_id) for x in burst_infos]
         burst_ids.sort()
-        if burst_ids != list(range(min(burst_ids), max(burst_ids) + 1)):
-            raise ValueError(f'All bursts must have consecutive burst IDs. Found: {burst_ids}.')
 
     @staticmethod
     def get_swath_name(burst_infos: list[BurstInfo], safe_path: Path, image_number: int) -> str:

--- a/tests/test_safe.py
+++ b/tests/test_safe.py
@@ -42,7 +42,9 @@ class TestSafe:
             Safe.check_group_validity(different_polarization_ends)  # type: ignore[arg-type]
 
         swath_nonoverlap = [burst1, BurstStub(*burst2._replace(burst_id=3))]
-        with pytest.raises(ValueError, match='Products from swaths IW1 and IW2 do not overlap'):
+        with pytest.raises(
+            ValueError, match='There can be no gaps in burst IDs accross a collection of bursts. Found:.*'
+        ):
             Safe.check_group_validity(swath_nonoverlap)  # type: ignore[arg-type]
 
     def test_get_name(self, burst_infos, tmp_path):

--- a/tests/test_swath.py
+++ b/tests/test_swath.py
@@ -54,7 +54,7 @@ class TestSwath:
             Swath.check_burst_group_validity(different_polarization)  # type: ignore[arg-type]
 
         non_consecutive_burst_ids = [burst1, BurstStub(*burst2._replace(burst_id=3))]
-        with pytest.raises(ValueError, match='All bursts must have consecutive burst IDs. Found:.*'):
+        with pytest.raises(ValueError, match='There can be no gaps in burst IDs accross a collection of bursts. Found:.*'):
             Swath.check_burst_group_validity(non_consecutive_burst_ids)  # type: ignore[arg-type]
 
     def test_get_swath_name(self, burst_infos):

--- a/tests/test_swath.py
+++ b/tests/test_swath.py
@@ -53,10 +53,6 @@ class TestSwath:
         with pytest.raises(ValueError, match='All bursts must have the same polarization. Found:.*'):
             Swath.check_burst_group_validity(different_polarization)  # type: ignore[arg-type]
 
-        non_consecutive_burst_ids = [burst1, BurstStub(*burst2._replace(burst_id=3))]
-        with pytest.raises(ValueError, match='There can be no gaps in burst IDs accross a collection of bursts. Found:.*'):
-            Swath.check_burst_group_validity(non_consecutive_burst_ids)  # type: ignore[arg-type]
-
     def test_get_swath_name(self, burst_infos):
         safe_path = Path('./S1A_IW_SLC__1SDV_20240408T015045_20240408T015113_053336_06778C_CB5D.SAFE')
         assert (


### PR DESCRIPTION
@forrestfwilliams, here is that PR, as requested! I built it off of @mfangaritav's branch to minimize divergence and keep PRs in order.

Currently, some valid contiguous collections of bursts are identified as invalid. Specifically, a "vertical zig-zag" of bursts will raise a `ValueError`.

For example, the following collection of bursts will produce an error indicating that burst ID 136221 is not included when it is:
```burst2safe S1_136220_IW3_20200604T022243_VV_AE68-BURST S1_136221_IW2_20200604T022245_VV_AE68-BURST S1_136222_IW3_20200604T022249_VV_AE68-BURST```

This occurs because `Swath.check_burst_group_validity` requires consecutive burst IDs in each swath, but that is not a requirement for a contiguous collection.

This PR:
- Removes the overly restrictive check in `Swath.check_burst_group_validity`
- Adds 2 static methods to `safe.py`
    - `Safe.make_burst_swath_mask` creates a mask of relative positions of bursts/swaths used for identifying invalid topologies
    - `Safe.count_components_and_holes` performs a BFS on the burst_swath_mask, counting connected components and holes in the topology
        - Note: avoided adding additional dependencies for BFS 
- Removes the non_consecutive_burst_ids check from test_swath.py, as disconnections and holes are  now caught earlier and tested in test_safe.py