### PR TITLE
Finish dropping Python 3.9, add Python 3.13

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python_version: ["3.10", "3.11", "3.12"]
+        python_version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,15 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.0.0]
 
+### Added
+* Added official support for Python 3.13.
+
 ### Changed
 * Removed `numpy<2.1.0` pin introduced in v1.1.1.
+* Upgraded aiohttp library to >=3.12.6, avoiding wrong requests in asynchronous tasks.
 
 ### Removed
-* Support for Python 3.9.
-
-## [1.4.6]
-
-### Changed
-* Upgraded aiohttp library to >=3.12.6, avoiding wrong requests in asynchronous tasks.
+* Removed support for Python 3.9.
 
 ### Fixed
 * Removed `warnings.filterwarnings('ignore')` and replacing it by disabling the `asf_search` logger. Fixes https://github.com/ASFHyP3/burst2safe/issues/160

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 * Removed `numpy<2.1.0` pin introduced in v1.1.1.
 * Upgraded aiohttp library to >=3.12.6, avoiding wrong requests in asynchronous tasks.
+* Enable [`pyupgrade (UP)`](https://docs.astral.sh/ruff/rules/#pyupgrade-up) for ruff and fix the resulting warnings.
 
 ### Removed
 * Removed support for Python 3.9.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ where = ["src"]
 
 [project]
 name = "burst2safe"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dynamic = ["version"]
 authors = [
     {name="Forrest Williams", email="ffwilliams2@alaska.edu"},
@@ -32,6 +32,7 @@ classifiers=[
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
   "gdal",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,8 +78,8 @@ quote-style = "single"
 [tool.ruff.lint]
 extend-select = [
     "I",   # isort: https://docs.astral.sh/ruff/rules/#isort-i
+    "UP",  # pyupgrade: https://docs.astral.sh/ruff/rules/#pyupgrade-up
     # TODO: Uncomment the following extensions and address their warnings:
-    # "UP",  # pyupgrade: https://docs.astral.sh/ruff/rules/#pyupgrade-up
     # "D",   # pydocstyle: https://docs.astral.sh/ruff/rules/#pydocstyle-d
     # "ANN", # annotations: https://docs.astral.sh/ruff/rules/#flake8-annotations-ann
     # "PTH", # use-pathlib-pth: https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth

--- a/src/burst2safe/auth.py
+++ b/src/burst2safe/auth.py
@@ -2,7 +2,6 @@ import netrc
 import os
 from pathlib import Path
 from platform import system
-from typing import Tuple, Union
 
 
 EARTHDATA_HOST = 'urs.earthdata.nasa.gov'
@@ -20,7 +19,7 @@ def get_netrc() -> Path:
     return netrc_file
 
 
-def find_creds_in_env(username_name, password_name) -> Union[Tuple[str, str], Tuple[None, None]]:
+def find_creds_in_env(username_name, password_name) -> tuple[str, str] | tuple[None, None]:
     """Find credentials for a service in the environment.
 
     Args:
@@ -38,7 +37,7 @@ def find_creds_in_env(username_name, password_name) -> Union[Tuple[str, str], Tu
     return None, None
 
 
-def find_creds_in_netrc(service) -> Union[Tuple[str, str], Tuple[None, None]]:
+def find_creds_in_netrc(service) -> tuple[str, str] | tuple[None, None]:
     """Find credentials for a service in the netrc file.
 
     Args:

--- a/src/burst2safe/base.py
+++ b/src/burst2safe/base.py
@@ -3,7 +3,7 @@ import hashlib
 from copy import deepcopy
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import List, Optional, Union, cast
+from typing import cast
 
 import lxml.etree as ET
 
@@ -14,9 +14,7 @@ SCHEMA = '{urn:ccsds:schema:xfdu:1}'
 
 
 class ListOfListElements:
-    def __init__(
-        self, inputs: List[ET._Element], start_line: Optional[int] = None, slc_lengths: Optional[List[int]] = None
-    ):
+    def __init__(self, inputs: list[ET._Element], start_line: int | None = None, slc_lengths: list[int] | None = None):
         """Initialize the ListOfListElements object.
 
         Args:
@@ -25,8 +23,8 @@ class ListOfListElements:
             slc_lengths: The total line lengths of the SLCs corresponding to each element.
         """
         self.inputs: list[ET._Element] = inputs
-        self.start_line: Optional[int] = start_line
-        self.slc_lengths: Optional[list[int]] = slc_lengths
+        self.start_line: int | None = start_line
+        self.slc_lengths: list[int] | None = slc_lengths
 
         self.name = self.inputs[0].tag
         elements = flatten([element.findall('*') for element in self.inputs])
@@ -64,7 +62,7 @@ class ListOfListElements:
         first_time = min([datetime.fromisoformat(sub.find(self.time_field).text) for sub in element])  # type: ignore[arg-type]
         return first_time
 
-    def get_unique_elements(self) -> List[ET._Element]:
+    def get_unique_elements(self) -> list[ET._Element]:
         """Get the elements without duplicates. Adjust line number if present.
 
         Returns:
@@ -96,7 +94,7 @@ class ListOfListElements:
         return uniques
 
     @staticmethod
-    def filter_by_line(element_list: List[ET._Element], line_bounds: tuple[float, float]) -> List[ET._Element]:
+    def filter_by_line(element_list: list[ET._Element], line_bounds: tuple[float, float]) -> list[ET._Element]:
         """Filter elements by line number.
 
         Args:
@@ -111,7 +109,7 @@ class ListOfListElements:
                 new_list.append(deepcopy(elem))
         return new_list
 
-    def update_line_numbers(self, elements: List[ET._Element]) -> None:
+    def update_line_numbers(self, elements: list[ET._Element]) -> None:
         """Update the line numbers of the elements.
 
         Args:
@@ -123,8 +121,8 @@ class ListOfListElements:
             element.find('line').text = str(standard_line - self.start_line)
 
     def filter_by_time(
-        self, elements: List[ET._Element], anx_bounds: tuple[datetime, datetime], buffer: timedelta
-    ) -> List[ET._Element]:
+        self, elements: list[ET._Element], anx_bounds: tuple[datetime, datetime], buffer: timedelta
+    ) -> list[ET._Element]:
         """Filter elements by time.
 
         Args:
@@ -149,7 +147,7 @@ class ListOfListElements:
         self,
         anx_bounds: tuple[datetime, datetime],
         buffer: timedelta = timedelta(seconds=3),
-        line_bounds: Optional[tuple[float, float]] = None,
+        line_bounds: tuple[float, float] | None = None,
     ) -> ET._Element:
         """Filter elements by time/line. Adjust line number if present.
 
@@ -215,7 +213,7 @@ def create_metadata_object(simple_name: str) -> ET._Element:
 
 
 def create_data_object(
-    simple_name: str, relative_path: Union[Path, str], rep_id: str, mime_type: str, size_bytes: int, md5: str
+    simple_name: str, relative_path: Path | str, rep_id: str, mime_type: str, size_bytes: int, md5: str
 ) -> ET._Element:
     """Create a data object element for a manifest.safe file.
 
@@ -281,12 +279,12 @@ class Annotation:
         self.slc_lengths = slc_lengths
 
         # annotation components to be extended by subclasses
-        self.ads_header: Optional[ET._Element] = None
-        self.xml: Union[ET._Element, ET._ElementTree, None] = None
+        self.ads_header: ET._Element | None = None
+        self.xml: ET._Element | ET._ElementTree | None = None
 
         # these attributes are updated when the annotation is written to a file
-        self.size_bytes: Optional[int] = None
-        self.md5: Optional[str] = None
+        self.size_bytes: int | None = None
+        self.md5: str | None = None
 
     def create_ads_header(self):
         """Create the ADS header for the annotation."""
@@ -296,7 +294,7 @@ class Annotation:
         ads_header.find('imageNumber').text = f'{self.image_number:03d}'
         self.ads_header = ads_header
 
-    def merge_lists(self, list_name: str, line_bounds: Optional[tuple[int, int]] = None) -> ET._Element:
+    def merge_lists(self, list_name: str, line_bounds: tuple[int, int] | None = None) -> ET._Element:
         """Merge lists of elements into a single list.
 
         Args:

--- a/src/burst2safe/burst2safe.py
+++ b/src/burst2safe/burst2safe.py
@@ -3,7 +3,6 @@
 from argparse import ArgumentParser
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Optional
 
 from shapely.geometry import Polygon
 
@@ -20,16 +19,16 @@ providing the absolute orbit number, extent, and polarizations arguments.
 
 
 def burst2safe(
-    granules: Optional[Iterable[str]] = None,
-    orbit: Optional[int] = None,
-    extent: Optional[Polygon] = None,
-    polarizations: Optional[list[str]] = None,
-    swaths: Optional[list[str]] = None,
+    granules: Iterable[str] | None = None,
+    orbit: int | None = None,
+    extent: Polygon | None = None,
+    polarizations: list[str] | None = None,
+    swaths: list[str] | None = None,
     mode: str = 'IW',
     min_bursts: int = 1,
     all_anns: bool = False,
     keep_files: bool = False,
-    work_dir: Optional[Path] = None,
+    work_dir: Path | None = None,
 ) -> Path:
     """Convert a set of burst granules to the ESA SAFE format.
 

--- a/src/burst2safe/burst2stack.py
+++ b/src/burst2safe/burst2stack.py
@@ -3,7 +3,6 @@
 from argparse import ArgumentParser
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
 
 from shapely.geometry import Polygon
 
@@ -22,17 +21,17 @@ an extent, and polarization(s).
 
 def burst2stack(
     extent: Polygon,
-    rel_orbit: Optional[int] = None,
-    start_date: Optional[datetime] = None,
-    end_date: Optional[datetime] = None,
-    polarizations: Optional[list[str]] = None,
-    swaths: Optional[list[str]] = None,
+    rel_orbit: int | None = None,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
+    polarizations: list[str] | None = None,
+    swaths: list[str] | None = None,
     mode: str = 'IW',
     min_bursts: int = 1,
     all_anns: bool = False,
     keep_files: bool = False,
-    work_dir: Optional[Path] = None,
-) -> List[Path]:
+    work_dir: Path | None = None,
+) -> list[Path]:
     """Convert a stack of burst granules to a stack of ESA SAFEs.
     Wraps the burst2safe function to handle multiple dates.
 

--- a/src/burst2safe/burst_id.py
+++ b/src/burst2safe/burst_id.py
@@ -204,6 +204,6 @@ def calculate_burstid(
         esa_burst_id = _calc_esa_burstid(time_since_anx, orbit_number_start, pream, beamtime)
 
     else:
-        raise InvalidModeNameError('Invalid mode name: %s' % mode)  # noqa: UP031
+        raise InvalidModeNameError(f'Invalid mode name: {mode}')
 
     return esa_burst_id, orbit_number

--- a/src/burst2safe/burst_id.py
+++ b/src/burst2safe/burst_id.py
@@ -204,6 +204,6 @@ def calculate_burstid(
         esa_burst_id = _calc_esa_burstid(time_since_anx, orbit_number_start, pream, beamtime)
 
     else:
-        raise InvalidModeNameError('Invalid mode name: %s' % mode)
+        raise InvalidModeNameError('Invalid mode name: %s' % mode)  # noqa: UP031
 
     return esa_burst_id, orbit_number

--- a/src/burst2safe/calibration.py
+++ b/src/burst2safe/calibration.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-from typing import Optional
 
 import lxml.etree as ET
 
@@ -19,7 +18,7 @@ class Calibration(Annotation):
             image_number: Image number.
         """
         super().__init__(burst_infos, 'calibration', ipf_version, image_number)
-        self.calibration_information: Optional[ET._Element] = None
+        self.calibration_information: ET._Element | None = None
         self.calibrattion_vector_list = None
 
     def create_calibration_information(self):

--- a/src/burst2safe/download.py
+++ b/src/burst2safe/download.py
@@ -1,7 +1,7 @@
 import asyncio
 import os
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 
 import aiohttp
 from tenacity import retry, retry_if_result, stop_after_attempt, stop_after_delay, wait_random

--- a/src/burst2safe/local2safe.py
+++ b/src/burst2safe/local2safe.py
@@ -5,7 +5,7 @@ import argparse
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, Union, cast
+from typing import cast
 
 from burst2safe import utils
 from burst2safe.burst_id import calculate_burstid
@@ -113,7 +113,7 @@ def local2safe(
     slc_dict: dict,
     all_anns: bool = False,
     keep_files: bool = False,
-    work_dir: Optional[Union[Path, str]] = None,
+    work_dir: Path | str | None = None,
 ) -> Path:
     """Convert a set of burst granules to the ESA SAFE format using local files
 

--- a/src/burst2safe/manifest.py
+++ b/src/burst2safe/manifest.py
@@ -1,7 +1,6 @@
 import hashlib
 from copy import deepcopy
 from pathlib import Path
-from typing import List, Optional, Union
 
 import lxml.etree as ET
 import numpy as np
@@ -49,9 +48,9 @@ class Manifest:
 
     def __init__(
         self,
-        content_units: List[ET._Element],
-        metadata_objects: List[ET._Element],
-        data_objects: List[ET._Element],
+        content_units: list[ET._Element],
+        metadata_objects: list[ET._Element],
+        data_objects: list[ET._Element],
         bbox: Polygon,
         template_manifest: ET._Element,
     ):
@@ -72,12 +71,12 @@ class Manifest:
         self.version = 'esa/safe/sentinel-1.0/sentinel-1/sar/level-1/slc/standard/iwdp'
 
         # Updated by methods
-        self.information_package_map: Optional[ET._Element] = None
-        self.metadata_section: Optional[ET._Element] = None
-        self.data_object_section: Optional[ET._Element] = None
-        self.xml: Union[ET._Element, ET._ElementTree, None] = None
-        self.path: Optional[Path] = None
-        self.crc: Optional[str] = None
+        self.information_package_map: ET._Element | None = None
+        self.metadata_section: ET._Element | None = None
+        self.data_object_section: ET._Element | None = None
+        self.xml: ET._Element | ET._ElementTree | None = None
+        self.path: Path | None = None
+        self.crc: str | None = None
 
     def create_information_package_map(self):
         """Create the information package map."""
@@ -141,7 +140,7 @@ class Manifest:
         self.create_metadata_section()
         self.create_data_object_section()
 
-        manifest = ET.Element('{%s}XFDU' % NAMESPACES['xfdu'], nsmap=NAMESPACES)
+        manifest = ET.Element('{%s}XFDU' % NAMESPACES['xfdu'], nsmap=NAMESPACES)  # noqa: UP031
         manifest.set('version', self.version)
         assert self.information_package_map is not None
         assert self.metadata_section is not None
@@ -178,7 +177,7 @@ class Kml:
             bbox: The bounding box of the product
         """
         self.bbox = bbox
-        self.xml: Union[ET._Element, ET._ElementTree, None] = None
+        self.xml: ET._Element | ET._ElementTree | None = None
 
     def assemble(self):
         """Assemble the components of the SAFE KML preview file."""
@@ -239,10 +238,10 @@ class Preview:
     def __init__(
         self,
         name: str,
-        product: List[str],
-        calibration: List[str],
-        measurement: List[str],
-        rfi: List[str] = [],
+        product: list[str],
+        calibration: list[str],
+        measurement: list[str],
+        rfi: list[str] = [],
     ):
         """Initialize a Preview object.
 
@@ -272,8 +271,8 @@ class Preview:
         ]
         if len(self.rfi) > 0:
             self.support.append('s1-level-1-rfi.xsd')
-        self.html: Optional[ET._ElementTree] = None
-        self.path: Optional[Path] = None
+        self.html: ET._ElementTree | None = None
+        self.path: Path | None = None
 
     def create_base(self):
         """Create the base HTML product preview."""

--- a/src/burst2safe/measurement.py
+++ b/src/burst2safe/measurement.py
@@ -1,7 +1,7 @@
 import hashlib
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, Tuple, cast
+from typing import cast
 
 import numpy as np
 from osgeo import gdal, osr
@@ -51,10 +51,10 @@ class Measurement:
         # TODO: sometimes bursts from different SLCs have different widths. Is this an issue?
         self.total_width = max(cast(int, info.width) for info in burst_infos)
 
-        self.data_mean: Optional[complex] = None
-        self.data_std: Optional[complex] = None
-        self.size_bytes: Optional[int] = None
-        self.md5: Optional[str] = None
+        self.data_mean: complex | None = None
+        self.data_std: complex | None = None
+        self.size_bytes: int | None = None
+        self.md5: str | None = None
         self.byte_offsets: list = []
 
     def get_data(self, band: int = 1) -> np.ndarray:
@@ -142,7 +142,7 @@ class Measurement:
                 self.size_bytes = len(file_bytes)
                 self.md5 = hashlib.md5(file_bytes).hexdigest()
 
-    def create_manifest_components(self) -> Tuple:
+    def create_manifest_components(self) -> tuple:
         """Create the components of the SAFE manifest for the measurement file.
 
         Returns:

--- a/src/burst2safe/noise.py
+++ b/src/burst2safe/noise.py
@@ -1,6 +1,5 @@
 # mypy: disable-error-code="union-attr"
 from copy import deepcopy
-from typing import Optional
 
 import lxml.etree as ET
 import numpy as np
@@ -21,9 +20,9 @@ class Noise(Annotation):
             image_number: Image number.
         """
         super().__init__(burst_infos, 'noise', ipf_version, image_number)
-        self.noise_vector_list: Optional[ET._Element] = None  # Only used in version < 2.90
-        self.range_vector_list: Optional[ET._Element] = None
-        self.azimuth_vector_list: Optional[ET._Element] = None
+        self.noise_vector_list: ET._Element | None = None  # Only used in version < 2.90
+        self.range_vector_list: ET._Element | None = None
+        self.azimuth_vector_list: ET._Element | None = None
 
     def create_range_vector_list(self):
         """Create the range vector list."""

--- a/src/burst2safe/product.py
+++ b/src/burst2safe/product.py
@@ -3,7 +3,7 @@ from collections.abc import Iterable
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Optional, cast
+from typing import cast
 
 import lxml.etree as ET
 import numpy as np
@@ -37,14 +37,14 @@ class Product(Annotation):
         super().__init__(burst_infos, 'product', ipf_version, image_number)
         self.dummy = dummy
         self.qulatity_information = None
-        self.general_annotation: Optional[ET._Element] = None
-        self.image_annotation: Optional[ET._Element] = None
-        self.doppler_centroid: Optional[ET._Element] = None
-        self.antenna_pattern: Optional[ET._Element] = None
-        self.swath_timing: Optional[ET._Element] = None
-        self.geolocation_grid: Optional[ET._Element] = None
-        self.coordinate_conversion: Optional[ET._Element] = None
-        self.swath_merging: Optional[ET._Element] = None
+        self.general_annotation: ET._Element | None = None
+        self.image_annotation: ET._Element | None = None
+        self.doppler_centroid: ET._Element | None = None
+        self.antenna_pattern: ET._Element | None = None
+        self.swath_timing: ET._Element | None = None
+        self.geolocation_grid: ET._Element | None = None
+        self.coordinate_conversion: ET._Element | None = None
+        self.swath_merging: ET._Element | None = None
         self.gcps: list = []
 
     def create_quality_information(self):

--- a/src/burst2safe/rfi.py
+++ b/src/burst2safe/rfi.py
@@ -1,6 +1,5 @@
 import warnings
 from copy import deepcopy
-from typing import Optional
 
 import lxml.etree as ET
 
@@ -23,9 +22,9 @@ class Rfi(Annotation):
             image_number: Image number.
         """
         super().__init__(burst_infos, 'rfi', ipf_version, image_number)
-        self.rfi_mitigation_applied: Optional[ET._Element] = None
-        self.rfi_detection_from_noise_report_list: Optional[ET._Element] = None
-        self.rfi_burst_report_list: Optional[ET._Element] = None
+        self.rfi_mitigation_applied: ET._Element | None = None
+        self.rfi_detection_from_noise_report_list: ET._Element | None = None
+        self.rfi_burst_report_list: ET._Element | None = None
 
     def create_rfi_mitigation_applied(self):
         """Create the rifMitigationApplied element."""

--- a/src/burst2safe/safe.py
+++ b/src/burst2safe/safe.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 from datetime import datetime
 from itertools import product
 from pathlib import Path
-from typing import List, Optional, Tuple, Union, cast
+from typing import cast
 
 import numpy as np
 from shapely.geometry import MultiPolygon, Polygon
@@ -19,9 +19,7 @@ from burst2safe.utils import BurstInfo, drop_duplicates, flatten, get_subxml_fro
 class Safe:
     """Class representing a SAFE file."""
 
-    def __init__(
-        self, burst_infos: list[BurstInfo], all_anns: bool = False, work_dir: Optional[Union[Path, str]] = None
-    ):
+    def __init__(self, burst_infos: list[BurstInfo], all_anns: bool = False, work_dir: Path | str | None = None):
         """Initialize a Safe object.
 
         Args:
@@ -40,8 +38,8 @@ class Safe:
         self.safe_path = self.work_dir / self.name
         self.swaths: list = []
         self.blank_products: list = []
-        self.manifest: Optional[Manifest] = None
-        self.kml: Optional[Kml] = None
+        self.manifest: Manifest | None = None
+        self.kml: Kml | None = None
 
         self.version = self.get_ipf_version(self.burst_infos[0].metadata_path)
         self.major_version, self.minor_version = [int(x) for x in self.version.split('.')]
@@ -230,7 +228,7 @@ class Safe:
         shutil.copy(self.support_dir.parent / 'logo.png', icon_dir / 'logo.png')
 
     @staticmethod
-    def create_representative_burst_set(template_bursts: Iterable[BurstInfo], swath: str, pol: str) -> List[BurstInfo]:
+    def create_representative_burst_set(template_bursts: Iterable[BurstInfo], swath: str, pol: str) -> list[BurstInfo]:
         """Create a representative burst set for a blank product.
 
         Args:
@@ -267,7 +265,7 @@ class Safe:
             representative_bursts.append(new_burst)
         return representative_bursts
 
-    def create_blank_products(self, image_number: int) -> List[Product]:
+    def create_blank_products(self, image_number: int) -> list[Product]:
         """Create blank product annotation for missing swaths.
 
         Args:
@@ -359,7 +357,7 @@ class Safe:
 
         return content_units, metadata_objects, data_objects
 
-    def compile_manifest_components(self) -> Tuple[List, List, List]:
+    def compile_manifest_components(self) -> tuple[list, list, list]:
         """Compile the manifest components for all files within the SAFE file.
 
         Returns:

--- a/src/burst2safe/search.py
+++ b/src/burst2safe/search.py
@@ -2,7 +2,6 @@ import logging
 from collections.abc import Iterable
 from datetime import datetime
 from itertools import product
-from typing import List, Optional, Tuple
 
 import asf_search
 import numpy as np
@@ -14,7 +13,7 @@ asf_logger = logging.getLogger(asf_search.__name__)
 asf_logger.disabled = True
 
 
-def find_granules(granules: Iterable[str]) -> List[S1BurstProduct]:
+def find_granules(granules: Iterable[str]) -> list[S1BurstProduct]:
     """Find granules by name using ASF Search.
 
     Args:
@@ -32,7 +31,7 @@ def find_granules(granules: Iterable[str]) -> List[S1BurstProduct]:
     return list(results)
 
 
-def add_surrounding_bursts(bursts: List[S1BurstProduct], min_bursts: int) -> List[S1BurstProduct]:
+def add_surrounding_bursts(bursts: list[S1BurstProduct], min_bursts: int) -> list[S1BurstProduct]:
     """Add bursts to the list to ensure each swath has at least `min_bursts` bursts.
     All bursts must be from the same absolute orbit, swath, and polarization.
 
@@ -66,12 +65,12 @@ def add_surrounding_bursts(bursts: List[S1BurstProduct], min_bursts: int) -> Lis
 
 
 def get_burst_group(
-    search_results: List[S1BurstProduct],
+    search_results: list[S1BurstProduct],
     pol: str,
-    swath: Optional[str] = None,
-    orbit: Optional[int] = None,
+    swath: str | None = None,
+    orbit: int | None = None,
     min_bursts: int = 0,
-) -> List[S1BurstProduct]:
+) -> list[S1BurstProduct]:
     """Find a group of bursts with the same polarization, swath and optionally orbit.
     Add surrounding bursts if the group is too small.
 
@@ -109,8 +108,8 @@ def get_burst_group(
 
 
 def sanitize_group_search_inputs(
-    polarizations: Optional[list] = None, swaths: Optional[list] = None, mode: str = 'IW'
-) -> Tuple[list[str], list[str]]:
+    polarizations: list | None = None, swaths: list | None = None, mode: str = 'IW'
+) -> tuple[list[str], list[str]]:
     """Sanitize inputs for group search.
 
     Args:
@@ -145,12 +144,12 @@ def sanitize_group_search_inputs(
 
 
 def add_missing_bursts(
-    search_results: List[S1BurstProduct],
-    polarizations: List[str],
-    swaths: List[str],
+    search_results: list[S1BurstProduct],
+    polarizations: list[str],
+    swaths: list[str],
     min_bursts: int,
     use_relative_orbit: bool,
-) -> List[S1BurstProduct]:
+) -> list[S1BurstProduct]:
     """Add missing bursts to the search results to ensure each swath/pol combo has at least `min_bursts` bursts.
 
     Args:
@@ -179,16 +178,16 @@ def add_missing_bursts(
 
 
 def find_group(
-    orbit: Optional[int],
+    orbit: int | None,
     footprint: Polygon,
-    polarizations: Optional[list[str]] = None,
-    swaths: Optional[list[str]] = None,
+    polarizations: list[str] | None = None,
+    swaths: list[str] | None = None,
     mode: str = 'IW',
     min_bursts: int = 1,
-    start_date: Optional[datetime] = None,
-    end_date: Optional[datetime] = None,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
     use_relative_orbit: bool = False,
-) -> List[S1BurstProduct]:
+) -> list[S1BurstProduct]:
     """Find burst groups using ASF Search.
 
     Args:
@@ -225,11 +224,11 @@ def find_group(
 
 
 def find_bursts(
-    granules: Optional[Iterable[str]] = None,
-    orbit: Optional[int] = None,
-    footprint: Optional[Polygon] = None,
-    polarizations: Optional[list[str]] = None,
-    swaths: Optional[list[str]] = None,
+    granules: Iterable[str] | None = None,
+    orbit: int | None = None,
+    footprint: Polygon | None = None,
+    polarizations: list[str] | None = None,
+    swaths: list[str] | None = None,
     mode: str = 'IW',
     min_bursts: int = 1,
 ) -> list[S1BurstProduct]:

--- a/src/burst2safe/utils.py
+++ b/src/burst2safe/utils.py
@@ -7,7 +7,6 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Dict, List, Optional, Union
 
 import lxml.etree as ET
 from asf_search.Products.S1BurstProduct import S1BurstProduct
@@ -24,24 +23,24 @@ asf_logger.disabled = True
 class BurstInfo:
     """Dataclass for storing burst information."""
 
-    granule: Optional[str]
-    slc_granule: Optional[str]
+    granule: str | None
+    slc_granule: str | None
     swath: str
     polarization: str
-    burst_id: Optional[int]
+    burst_id: int | None
     burst_index: int
     direction: str
     absolute_orbit: int
     relative_orbit: int
-    date: Optional[datetime]
-    data_url: Optional[str]
-    data_path: Optional[Path]
-    metadata_url: Optional[str]
+    date: datetime | None
+    data_url: str | None
+    data_path: Path | None
+    metadata_url: str | None
     metadata_path: Path
-    start_utc: Optional[datetime] = None
-    stop_utc: Optional[datetime] = None
-    length: Optional[int] = None
-    width: Optional[int] = None
+    start_utc: datetime | None = None
+    stop_utc: datetime | None = None
+    length: int | None = None
+    width: int | None = None
 
     def add_shape_info(self):
         """Add shape information to the BurstInfo object."""
@@ -109,7 +108,7 @@ def create_burst_info(product: S1BurstProduct, work_dir: Path) -> BurstInfo:
     return burst_info
 
 
-def get_burst_infos(products: Iterable[S1BurstProduct], work_dir: Optional[Path]) -> List[BurstInfo]:
+def get_burst_infos(products: Iterable[S1BurstProduct], work_dir: Path | None) -> list[BurstInfo]:
     """Get burst information from ASF Search.
 
     Args:
@@ -128,7 +127,7 @@ def get_burst_infos(products: Iterable[S1BurstProduct], work_dir: Optional[Path]
     return burst_info_list
 
 
-def sort_burst_infos(burst_info_list: List[BurstInfo]) -> Dict:
+def sort_burst_infos(burst_info_list: list[BurstInfo]) -> dict:
     """Sort BurstInfo objects by swath and polarization.
 
     Args:
@@ -155,7 +154,7 @@ def sort_burst_infos(burst_info_list: List[BurstInfo]) -> Dict:
     return burst_infos
 
 
-def optional_wd(wd: Optional[Union[Path, str]] = None) -> Path:
+def optional_wd(wd: Path | str | None = None) -> Path:
     """Return the working directory as a Path object
 
     Args:
@@ -184,8 +183,8 @@ def calculate_crc16(file_path: Path) -> str:
 
 
 def get_subxml_from_metadata(
-    metadata_path: Path, xml_type: str, subswath: Optional[str] = None, polarization: Optional[str] = None
-) -> Optional[ET._Element]:
+    metadata_path: Path, xml_type: str, subswath: str | None = None, polarization: str | None = None
+) -> ET._Element | None:
     """Extract child xml info from ASF combined metadata file.
 
     Args:
@@ -223,17 +222,17 @@ def get_subxml_from_metadata(
     return desired_metadata
 
 
-def flatten(list_of_lists: List[List]) -> List:
+def flatten(list_of_lists: list[list]) -> list:
     """Flatten a list of lists."""
     return [item for sublist in list_of_lists for item in sublist]
 
 
-def drop_duplicates(input_list: List) -> List:
+def drop_duplicates(input_list: list) -> list:
     """Drop duplicates from a list, while preserving order."""
     return list(dict.fromkeys(input_list))
 
 
-def set_text(element: ET._Element, text: Union[str, int]) -> None:
+def set_text(element: ET._Element, text: str | int) -> None:
     """Set the text of an element if it is not None.
 
     Args:


### PR DESCRIPTION
Summary:
- Fully drop support for Python 3.9
- Add support for Python 3.13
- Fix the Changelog
- Apply Python syntax upgrades via ruff