### PR TITLE
Bug/catch swath gap

### DIFF
--- a/src/burst2safe/safe.py
+++ b/src/burst2safe/safe.py
@@ -124,7 +124,7 @@ class Safe:
             return
 
         # Confirms that there are no gaps in swath coverage for each burst
-        burst_id_dict: dict[str, list[int]] = defaultdict(list)
+        burst_id_dict: dict[int, list[int]] = defaultdict(list)
         for swath, info in burst_range.items():
             for num in set(next(iter(info.values()))):
                 burst_id_dict[num].append(int(swath[-1]))

--- a/src/burst2safe/safe.py
+++ b/src/burst2safe/safe.py
@@ -7,7 +7,6 @@ from itertools import product
 from pathlib import Path
 from typing import List, Optional, Tuple, Union, cast
 
-import numpy as np
 from shapely.geometry import MultiPolygon, Polygon
 
 from burst2safe.base import create_content_unit, create_data_object, create_metadata_object
@@ -125,14 +124,11 @@ class Safe:
             return
 
         # Confirms that there are no gaps in swath coverage for each burst
-        burst_id_dict = defaultdict(list)
-        _ = [
-            burst_id_dict[num].append(int(swath[-1]))
-            for swath, info in burst_range.items()
-            for num in set(next(iter(info.values())))
-        ]
+        burst_id_dict: dict[str, list[int]] = defaultdict(list)
+        for swath, info in burst_range.items():
+            for num in set(next(iter(info.values()))):
+                burst_id_dict[num].append(int(swath[-1]))
 
-        burst_id_dict = dict(burst_id_dict)
         for id, swaths in burst_id_dict.items():
             if max(swaths) + 1 - min(swaths) > len(swaths):
                 msg = (

--- a/src/burst2safe/safe.py
+++ b/src/burst2safe/safe.py
@@ -129,10 +129,10 @@ class Safe:
             for num in set(next(iter(info.values()))):
                 burst_id_dict[num].append(int(swath[-1]))
 
-        for id, swaths in burst_id_dict.items():
-            if max(swaths) + 1 - min(swaths) > len(swaths):
+        for id, burst_swaths in burst_id_dict.items():
+            if max(burst_swaths) + 1 - min(burst_swaths) > len(burst_swaths):
                 msg = (
-                    f'No included burst can have gaps in swath coverage.\nFound {id}: {[f"IW{num}" for num in swaths]}.'
+                    f'No included burst can have gaps in swath coverage.\nFound {id}: {[f"IW{n}" for n in burst_swaths]}.'
                 )
                 raise ValueError(msg)
 

--- a/src/burst2safe/safe.py
+++ b/src/burst2safe/safe.py
@@ -131,9 +131,7 @@ class Safe:
 
         for id, burst_swaths in burst_id_dict.items():
             if max(burst_swaths) + 1 - min(burst_swaths) > len(burst_swaths):
-                msg = (
-                    f'No included burst can have gaps in swath coverage.\nFound {id}: {[f"IW{n}" for n in burst_swaths]}.'
-                )
+                msg = f'No included burst can have gaps in swath coverage.\nFound {id}: {[f"IW{n}" for n in burst_swaths]}.'
                 raise ValueError(msg)
 
     def get_name(self, unique_id: str = '0000') -> str:

--- a/tests/test_safe.py
+++ b/tests/test_safe.py
@@ -41,9 +41,15 @@ class TestSafe:
         with pytest.raises(ValueError, match='Polarization groups in swath .* end burst id.*'):
             Safe.check_group_validity(different_polarization_ends)  # type: ignore[arg-type]
 
-        swath_nonoverlap = [burst1, BurstStub(*burst2._replace(burst_id=3))]
+        burst_gap_in_swath = [burst1, BurstStub(*burst2._replace(burst_id=3))]
         with pytest.raises(ValueError, match='Products from swaths IW1 and IW2 do not overlap'):
-            Safe.check_group_validity(swath_nonoverlap)  # type: ignore[arg-type]
+            Safe.check_group_validity(burst_gap_in_swath)  # type: ignore[arg-type]
+
+        swath_gap_in_burst = [burst1, BurstStub(*burst1._replace(swath='IW3'))]
+        with pytest.raises(
+            ValueError, match="No included burst can have gaps in swath coverage.\nFound 1: ['IW1', 'IW3']."
+        ):
+            Safe.check_group_validity(swath_gap_in_burst)  # type: ignore[arg-type]
 
     def test_get_name(self, burst_infos, tmp_path):
         tmp_bursts = [deepcopy(x) for x in burst_infos]


### PR DESCRIPTION
This PR updates a check to catch gaps in swaths for all included bursts.

burst_1 swaths: ["IW1", "IW2", "IW3"]  ✅ 
burst_1 swaths: ["IW2", "IW3"]  ✅ 
burst_1 swaths: ["IW1", "IW2"]  ✅ 
burst_1 swaths: ["IW1", "IW3"]  ❌