### PR TITLE
Add IPF versions for S1D

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,11 @@ i.e. result in a different SAFE structure compared with the previous version:
    When it finishes, it should print which versions resulted in differences.
    You should go back to the `VERSIONS` list
    and change the `important` attribute for those versions to `True`.
+1. Finally, uncomment the older versions, and then commit the changes to add the new versions.
+
+If there are no new "important" versions, you're done.
+
+TODO: finish documenting script usage
 
 ## License
 `burst2safe` is licensed under the BSD 2-Clause License. See the LICENSE file for more details.

--- a/README.md
+++ b/README.md
@@ -142,7 +142,12 @@ A full accounting of omitted datasets and differing fields can be found below:
 ### IPF Version Compatibility
 At this time, we are not aware of any compatibility issues with older Sentinel-1 Instrument Processing Facility (IPF) versions. However, if you do encounter any incompatibilities [please open an issue](https://github.com/ASFHyP3/burst2safe/issues/new), so we can fix it!
 
-## Developer Setup
+## Developers
+
+This section is only for developers. Normal users can skip this section.
+
+### Developer Setup
+
 1. Ensure that conda is installed on your system (we recommend using [mambaforge](https://github.com/conda-forge/miniforge#mambaforge) to reduce setup times).
 2. Download a local version of the `burst2safe` repository (`git clone https://github.com/ASFHyP3/burst2safe.git`)
 3. In the base directory for this project call `mamba env create -f environment.yml` to create your Python environment, then activate it (`mamba activate burst2safe`)
@@ -157,7 +162,7 @@ mamba activate burst2safe
 python -m pip install -e .
 ```
 
-## Adding Support for New IPF Versions
+### Adding Support for New IPF Versions
 
 When new [IPF versions](https://sar-mpc.eu/processor/ipf/) are added,
 a burst2safe maintainer should update the [IPF integration tests](./tests/test_ipf.py)
@@ -184,11 +189,11 @@ i.e. result in a different SAFE structure compared with the previous version:
    When it finishes, it should print which versions resulted in differences.
    You should go back to the `VERSIONS` list
    and change the `important` attribute for those versions to `True`.
-1. Finally, uncomment the older versions, and then commit the changes to add the new versions.
+1. Finally, uncomment the older versions and then commit the changes to add the new versions.
 
 If there are no new "important" versions, you're done.
-
-TODO: finish documenting script usage
+Otherwise, see https://github.com/ASFHyP3/burst2safe/issues/244 for a sketch of the steps for adding new important versions,
+and then update this README section with the complete steps when you're done.
 
 ## License
 `burst2safe` is licensed under the BSD 2-Clause License. See the LICENSE file for more details.

--- a/README.md
+++ b/README.md
@@ -176,8 +176,9 @@ i.e. result in a different SAFE structure compared with the previous version:
 1. Add the new IPF versions to the `VERSIONS` list
    defined globally in the [`identify_ipf_differences`](./tests/etc/identify_ipf_differences.py) script.
    Specify `False` for the `important` attribute for each new `Version` object.
-1. You probably want to comment out all of the older versions, except for the most recent older version
-   (the old version immediately before the new versions). This is because the command that you're about to run
+1. To help the script run faster, you probably want to comment out all of the older versions,
+   except for the most recent older version (the version immediately before the new versions).
+   This is because the command that you're about to run
    works by comparing each version to the previous version to determine if it changes the SAFE structure.
 1. From within the activated mamba environment, run:
    ```

--- a/README.md
+++ b/README.md
@@ -164,11 +164,9 @@ python -m pip install -e .
 
 ### Adding Support for New IPF Versions
 
-When new [IPF versions](https://sar-mpc.eu/processor/ipf/) are added,
-a burst2safe maintainer should update the [IPF integration tests](./tests/test_ipf.py)
-to include the new versions.
+Follow the steps below to add support for new [IPF versions](https://sar-mpc.eu/processor/ipf/).
 
-To update the tests, you will need to use the [`identify_ipf_differences`](./tests/etc/identify_ipf_differences.py) script.
+You will need to use the [`identify_ipf_differences`](./tests/etc/identify_ipf_differences.py) script.
 You may want to read the script to understand how it works.
 
 First, identify which IPF versions are "important",

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ i.e. result in a different SAFE structure compared with the previous version:
    and change the `important` attribute for those versions to `True`.
 1. Finally, uncomment the older versions and then commit the changes to add the new versions.
 
-If there are no new "important" versions, you're done.
+If there were no new "important" versions, you're done.
 Otherwise, see https://github.com/ASFHyP3/burst2safe/issues/244 for a sketch of the steps for adding new important versions,
 and then update this README section with the complete steps when you're done.
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ mamba activate burst2safe
 python -m pip install -e .
 ```
 
-## Adding IPF Versions
+## Adding Support for New IPF Versions
 
 When new [IPF versions](https://sar-mpc.eu/processor/ipf/) are added,
 a burst2safe maintainer should update the [IPF integration tests](./tests/test_ipf.py)

--- a/README.md
+++ b/README.md
@@ -157,6 +157,34 @@ mamba activate burst2safe
 python -m pip install -e .
 ```
 
+## Adding IPF Versions
+
+When new [IPF versions](https://sar-mpc.eu/processor/ipf/) are added,
+a burst2safe maintainer should update the [IPF integration tests](./tests/test_ipf.py)
+to include the new versions.
+
+To update the tests, you will need to use the [`identify_ipf_differences`](./tests/etc/identify_ipf_differences.py) script.
+You may want to read the script to understand how it works.
+
+First, identify which IPF versions are "important",
+i.e. result in a different SAFE structure compared with the previous version:
+
+1. Follow [Developer Setup](#developer-setup).
+1. Add the new IPF versions to the `VERSIONS` list
+   defined globally in the [`identify_ipf_differences`](./tests/etc/identify_ipf_differences.py) script.
+   Specify `False` for the `important` attribute for each new `Version` object.
+1. You probably want to comment out all of the older versions, except for the most recent older version
+   (the old version immediately before the new versions). This is because the command that you're about to run
+   works by comparing each version to the previous version to determine if it changes the SAFE structure.
+1. From within the activated mamba environment, run:
+   ```
+   python tests/etc/identify_ipf_differences.py identify_changing_versions
+   ```
+   This command downloads some large files and takes awhile to run.
+   When it finishes, it should print which versions resulted in differences.
+   You should go back to the `VERSIONS` list
+   and change the `important` attribute for those versions to `True`.
+
 ## License
 `burst2safe` is licensed under the BSD 2-Clause License. See the LICENSE file for more details.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ suppress-dummy-args = true
 "tests/*" = ["D1", "ANN"]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.12"
 warn_redundant_casts = true
 warn_unused_ignores = true
 warn_unreachable = true

--- a/tests/etc/identify_ipf_differences.py
+++ b/tests/etc/identify_ipf_differences.py
@@ -61,6 +61,11 @@ VERSIONS = [
     Version('3.80', True),
     Version('3.90', False),
     Version('3.91', False),
+    Version('3.92', False),
+    Version('4.00', False),
+    Version('4.01', False),
+    Version('4.02', False),
+    Version('4.03', False),
 ]
 
 


### PR DESCRIPTION
I ran:

```
python tests/etc/identify_ipf_differences.py identify_changing_versions
```

and it did not flag any of the new versions.

I confirmed that neither of the other two workflows `download_representative_support` or `find_representative_bursts` do anything for versions that aren't marked "important".